### PR TITLE
msu1: return to previous flag behavior for $2005

### DIFF
--- a/bsnes/snes/chip/msu1/msu1.cpp
+++ b/bsnes/snes/chip/msu1/msu1.cpp
@@ -155,6 +155,8 @@ void MSU1::mmio_write(unsigned addr, uint8 data) {
       }
     }
     mmio.audio_busy   = false;
+    mmio.audio_repeat = false;
+    mmio.audio_play   = false;
     mmio.audio_error  = !audiofile.open();
   }
 


### PR DESCRIPTION
per byuu, this is the intended behavior and the removal was an
unintended regression in higan v95. reverting will continue to keep it
compatible with most higan versions and the sd2snes