### PR TITLE
Revert "* view actual SMP bus instead of APU RAM * Merge pull request #78 from undisbeliever/update-debugger More updates to the debugger * Allow the user to sort the Sprite Viewer columns Decided to move the OAM name table bit into the "Char" column so it will be included in the sort. Also decided that refresh() should not change the user selected row. This required me remember the selected row so it could be re-selected after QTreeWidget has sorted the model. Unfortunately this can lead to the occasional infinite signal call loop, necessitating the inRefreshCall test to ensure refresh() is only called once. * Improve column spacing in Sprite Viewer * Display selected object in Sprite Viewer * Only scale the vram canvas once. On my system this dramatically reduces cpu usage from 18.5% to 4.6% when quickly scrolling the VRAM viewer scrollbar[1]. [1]: Tested on a i5-3317U 1.70GHz CPU and no ROM loaded in the emulator."

### DIFF
--- a/bsnes/snes/debugger/debugger.cpp
+++ b/bsnes/snes/debugger/debugger.cpp
@@ -46,7 +46,8 @@ uint8 Debugger::read(Debugger::MemorySource source, unsigned addr) {
     } break;
 
     case MemorySource::APUBus: {
-      return smp.op_debugread(addr & 0xffff);
+      if((addr & 0xffc0) == 0xffc0) return smp.iplrom[addr & 0x3f];
+      return memory::apuram.read(addr & 0xffff);
     } break;
 
     case MemorySource::APURAM: {
@@ -95,8 +96,7 @@ void Debugger::write(Debugger::MemorySource source, unsigned addr, uint8 data) {
     case MemorySource::CPUBus: {
       bus.write(addr & 0xffffff, data);
     } break;
-    
-    case MemorySource::APUBus:
+
     case MemorySource::APURAM: {
       memory::apuram.write(addr & 0xffff, data);
     } break;

--- a/bsnes/snes/smp/core/disassembler/disassembler.cpp
+++ b/bsnes/snes/smp/core/disassembler/disassembler.cpp
@@ -1,5 +1,10 @@
 #ifdef SMPCORE_CPP
 
+uint8 SMPcore::disassemble_read(uint16 addr) {
+  if(addr >= 0xffc0) return smp.iplrom[addr & 0x3f];
+  return memory::apuram[addr];
+}
+
 uint16 SMPcore::relb(int8 offset, int op_len, uint16 pc) {
   return pc + op_len + offset;
 }
@@ -11,13 +16,10 @@ void SMPcore::disassemble_opcode(char *output, uint16 addr) {
   s = output;
 
   sprintf(s, "..%.4x ", addr);
-  
-  SNES::debugger.bus_access = true;
-  op  = smp.op_debugread(addr + 0);
-  op0 = smp.op_debugread(addr + 1);
-  op1 = smp.op_debugread(addr + 2);
-  SNES::debugger.bus_access = false;
-  
+
+  op  = disassemble_read(addr + 0);
+  op0 = disassemble_read(addr + 1);
+  op1 = disassemble_read(addr + 2);
   opw = (op0) | (op1 << 8);
   opdp0 = ((unsigned)regs.p.p << 8) + op0;
   opdp1 = ((unsigned)regs.p.p << 8) + op1;

--- a/bsnes/snes/smp/core/disassembler/disassembler.hpp
+++ b/bsnes/snes/smp/core/disassembler/disassembler.hpp
@@ -1,2 +1,3 @@
 void disassemble_opcode(char *output, uint16 addr);
+inline uint8 disassemble_read(uint16 addr);
 inline uint16 relb(int8 offset, int op_len, uint16 pc);

--- a/bsnes/snes/smp/memory/memory.cpp
+++ b/bsnes/snes/smp/memory/memory.cpp
@@ -11,10 +11,6 @@ alwaysinline void SMP::ram_write(uint16 addr, uint8 data) {
   if(status.ram_writable && !status.ram_disabled) memory::apuram[addr] = data;
 }
 
-uint8 SMP::op_debugread(uint16 addr) {
-  return op_busread(addr);
-}
-
 alwaysinline uint8 SMP::op_busread(uint16 addr) {
   uint8 r;
   if((addr & 0xfff0) == 0x00f0) {  //00f0-00ff
@@ -40,8 +36,7 @@ alwaysinline uint8 SMP::op_busread(uint16 addr) {
       case 0xf5:    //CPUIO1
       case 0xf6:    //CPUIO2
       case 0xf7: {  //CPUIO3
-        if (!Memory::debugger_access())
-          synchronize_cpu();
+        synchronize_cpu();
         r = port.cpu_to_smp[addr & 3];
       } break;
 
@@ -58,20 +53,17 @@ alwaysinline uint8 SMP::op_busread(uint16 addr) {
 
       case 0xfd: {  //T0OUT -- 4-bit counter value
         r = t0.stage3_ticks & 15;
-        if (!Memory::debugger_access())
-          t0.stage3_ticks = 0;
+        t0.stage3_ticks = 0;
       } break;
 
       case 0xfe: {  //T1OUT -- 4-bit counter value
         r = t1.stage3_ticks & 15;
-        if (!Memory::debugger_access())
-          t1.stage3_ticks = 0;
+        t1.stage3_ticks = 0;
       } break;
 
       case 0xff: {  //T2OUT -- 4-bit counter value
         r = t2.stage3_ticks & 15;
-        if (!Memory::debugger_access())
-          t2.stage3_ticks = 0;
+        t2.stage3_ticks = 0;
       } break;
     }
   } else {

--- a/bsnes/snes/smp/memory/memory.hpp
+++ b/bsnes/snes/smp/memory/memory.hpp
@@ -1,7 +1,3 @@
-public:
-uint8 op_debugread(uint16 addr);
-
-private:
 uint8 ram_read(uint16 addr);
 void ram_write(uint16 addr, uint8 data);
 

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -1,40 +1,66 @@
 #include "oam-viewer.moc"
 OamViewer *oamViewer;
 
-OamObject OamObject::getObject(unsigned i) {
-  OamObject obj;
+void OamViewer::show() {
+  Window::show();
+  refresh();
+}
 
-  uint8_t d0 = SNES::memory::oam[(i << 2) + 0];
-  uint8_t d1 = SNES::memory::oam[(i << 2) + 1];
-  uint8_t d2 = SNES::memory::oam[(i << 2) + 2];
-  uint8_t d3 = SNES::memory::oam[(i << 2) + 3];
-  uint8_t d4 = SNES::memory::oam[512 + (i >> 2)];
-  bool x    = d4 & (1 << ((i & 3) << 1));
-  bool size = d4 & (2 << ((i & 3) << 1));
+void OamViewer::refresh() {
+  canvas->image->fill(0x000000);
 
-  switch(SNES::ppu.oam_base_size()) { default:
-    case 0: obj.width = !size ?  8 : 16; obj.height = !size ?  8 : 16; break;
-    case 1: obj.width = !size ?  8 : 32; obj.height = !size ?  8 : 32; break;
-    case 2: obj.width = !size ?  8 : 64; obj.height = !size ?  8 : 64; break;
-    case 3: obj.width = !size ? 16 : 32; obj.height = !size ? 16 : 32; break;
-    case 4: obj.width = !size ? 16 : 64; obj.height = !size ? 16 : 64; break;
-    case 5: obj.width = !size ? 32 : 64; obj.height = !size ? 32 : 64; break;
-    case 6: obj.width = !size ? 16 : 32; obj.height = !size ? 32 : 64; break;
-    case 7: obj.width = !size ? 16 : 32; obj.height = !size ? 32 : 32; break;
+  QList<QTreeWidgetItem*> items = list->findItems("", Qt::MatchContains);
+  for(unsigned v = 0; v < items.count(); v++) {
+    QTreeWidgetItem *item = items[v];
+    unsigned i = item->data(0, Qt::UserRole).toUInt();
+
+    uint8_t d0 = SNES::memory::oam[(i << 2) + 0];
+    uint8_t d1 = SNES::memory::oam[(i << 2) + 1];
+    uint8_t d2 = SNES::memory::oam[(i << 2) + 2];
+    uint8_t d3 = SNES::memory::oam[(i << 2) + 3];
+    uint8_t d4 = SNES::memory::oam[512 + (i >> 2)];
+    bool x    = d4 & (1 << ((i & 3) << 1));
+    bool size = d4 & (2 << ((i & 3) << 1));
+
+    //TODO: create method to expose ChipDebugger::property values by name
+    unsigned width, height;
+    switch(SNES::ppu.oam_base_size()) { default:
+      case 0: width = !size ?  8 : 16; height = !size ?  8 : 16; break;
+      case 1: width = !size ?  8 : 32; height = !size ?  8 : 32; break;
+      case 2: width = !size ?  8 : 64; height = !size ?  8 : 64; break;
+      case 3: width = !size ? 16 : 32; height = !size ? 16 : 32; break;
+      case 4: width = !size ? 16 : 64; height = !size ? 16 : 64; break;
+      case 5: width = !size ? 32 : 64; height = !size ? 32 : 64; break;
+      case 6: width = !size ? 16 : 32; height = !size ? 32 : 64; break;
+      case 7: width = !size ? 16 : 32; height = !size ? 32 : 32; break;
+    }
+
+    signed xpos = (x << 8) + d0;
+    if(xpos > 256) xpos = sclip<9>(xpos);
+    unsigned ypos = d1;
+    unsigned character = d2;
+    unsigned priority = (d3 >> 4) & 3;
+    unsigned palette = (d3 >> 1) & 7;
+    string flags;
+    if(d3 & 0x80) flags << "V";
+    if(d3 & 0x40) flags << "H";
+    if(d3 & 0x01) flags << "N";
+
+    item->setText(1, string() << width << "x" << height);
+    item->setText(2, string() << xpos);
+    item->setText(3, string() << ypos);
+    item->setText(4, string() << character);
+    item->setText(5, string() << priority);
+    item->setText(6, string() << palette);
+    item->setText(7, flags);
   }
 
-  obj.xpos = (x << 8) + d0;
-  if(obj.xpos > 256) obj.xpos = sclip<9>(obj.xpos);
+  for(unsigned i = 0; i <= 7; i++) list->resizeColumnToContents(i);
+  canvas->update();
+}
 
-  obj.ypos = d1;
-  obj.character = d2;
-  obj.priority = (d3 >> 4) & 3;
-  obj.palette = (d3 >> 1) & 7;
-  obj.hFlip = d3 & 0x80;
-  obj.vFlip = d3 & 0x40;
-  obj.table = d3 & 0x01;
-
-  return obj;
+void OamViewer::autoUpdate() {
+  if(autoUpdateBox->isChecked()) refresh();
 }
 
 OamViewer::OamViewer() {
@@ -42,8 +68,6 @@ OamViewer::OamViewer() {
   setWindowTitle("Sprite Viewer");
   setGeometryString(&config().geometry.oamViewer);
   application.windowList.append(this);
-
-  inRefreshCall = false;
 
   layout = new QHBoxLayout;
   layout->setAlignment(Qt::AlignLeft);
@@ -57,25 +81,13 @@ OamViewer::OamViewer() {
   list->setAllColumnsShowFocus(true);
   list->setAlternatingRowColors(true);
   list->setRootIsDecorated(false);
-  list->setUniformRowHeights(true);
   list->setSortingEnabled(false);
   layout->addWidget(list);
 
-  unsigned dw = list->fontMetrics().width('0');
-  list->setColumnWidth(0, dw * 4);
-  list->setColumnWidth(1, dw * 8);
-  list->setColumnWidth(2, dw * 6);
-  list->setColumnWidth(3, dw * 6);
-  list->setColumnWidth(4, dw * 6);
-  list->setColumnWidth(5, dw * 6);
-  list->setColumnWidth(6, dw * 6);
-  list->setColumnWidth(7, dw * 6);
-
   for(unsigned i = 0; i < 128; i++) {
     QTreeWidgetItem *item = new QTreeWidgetItem(list);
-    item->setData(0, Qt::DisplayRole, i);
     item->setData(0, Qt::UserRole, QVariant(i));
-    item->setTextAlignment(0, Qt::AlignRight);
+    item->setTextAlignment(0, Qt::AlignHCenter);
     item->setTextAlignment(1, Qt::AlignHCenter);
     item->setTextAlignment(2, Qt::AlignRight);
     item->setTextAlignment(3, Qt::AlignRight);
@@ -83,20 +95,16 @@ OamViewer::OamViewer() {
     item->setTextAlignment(5, Qt::AlignRight);
     item->setTextAlignment(6, Qt::AlignRight);
     item->setTextAlignment(7, Qt::AlignLeft);
+    item->setText(0, string() << i);
   }
-  list->setCurrentItem(NULL);
-
-  list->sortItems(0, Qt::AscendingOrder);
-  list->setSortingEnabled(true);
-
 
   controlLayout = new QVBoxLayout;
   controlLayout->setAlignment(Qt::AlignTop);
   controlLayout->setSpacing(0);
   layout->addLayout(controlLayout);
 
-
-  canvas = new OamCanvas;
+  canvas = new Canvas;
+  canvas->setFixedSize(128, 128);
   controlLayout->addWidget(canvas);
 
   autoUpdateBox = new QCheckBox("Auto update");
@@ -105,162 +113,15 @@ OamViewer::OamViewer() {
   refreshButton = new QPushButton("Refresh");
   controlLayout->addWidget(refreshButton);
 
-
   connect(refreshButton, SIGNAL(released()), this, SLOT(refresh()));
-  connect(list, SIGNAL(itemSelectionChanged()), this, SLOT(onSelectedChanged()));
 }
 
-void OamViewer::show() {
-  Window::show();
-  refresh();
+void OamViewer::Canvas::paintEvent(QPaintEvent*) {
+  QPainter painter(this);
+  painter.drawImage(0, 0, *image);
 }
 
-void OamViewer::autoUpdate() {
-  if(autoUpdateBox->isChecked()) refresh();
-}
-
-void OamViewer::refresh() {
-  // Required to prevent the occasional infinite signal call loop.
-  if(inRefreshCall) return;
-  inRefreshCall = true;
-
-  int selectedRow = -1;
-  if (list->currentItem()) selectedRow = list->currentIndex().row();
-
-  list->setSortingEnabled(false);
-
-  for(unsigned r = 0; r < list->topLevelItemCount(); r++) {
-    QTreeWidgetItem *item = list->topLevelItem(r);
-    unsigned i = item->data(0, Qt::UserRole).toUInt();
-
-    OamObject obj = OamObject::getObject(i);
-
-    string flags;
-    if(obj.hFlip) flags << "V";
-    if(obj.vFlip) flags << "H";
-
-    item->setText(1, string() << obj.width << "x" << obj.height);
-    item->setData(2, Qt::DisplayRole, obj.xpos);
-    item->setData(3, Qt::DisplayRole, obj.ypos);
-    item->setData(4, Qt::DisplayRole, obj.character + (obj.table << 8));
-    item->setData(5, Qt::DisplayRole, obj.priority);
-    item->setData(6, Qt::DisplayRole, obj.palette);
-    item->setText(7, flags);
-  }
-
-  list->setSortingEnabled(true);
-
-  if(selectedRow >= 0 && selectedRow < list->topLevelItemCount()) {
-    list->setCurrentItem(list->topLevelItem(selectedRow));
-  }
-  canvas->refresh();
-
-  inRefreshCall = false;
-}
-
-void OamViewer::onSelectedChanged() {
-  QTreeWidgetItem *item = list->currentItem();
-
-  int s = -1;
-  if (item) s = item->data(0, Qt::UserRole).toUInt();
-
-  canvas->setSelected(s);
-  refresh();
-}
-
-OamCanvas::OamCanvas() {
-  setFrameStyle(QFrame::Shape::Panel | QFrame::Sunken);
-  setLineWidth(2);
-
-  selected = -1;
-  setScale(2);
-}
-
-void OamCanvas::paintEvent(QPaintEvent*e) {
-  QFrame::paintEvent(e);
-
-  if(!image.isNull()) {
-    QPainter painter(this);
-    painter.setRenderHints(0);
-
-    unsigned x = (width() - image.width()) / 2;
-    unsigned y = (width() - image.height()) / 2;
-    painter.drawImage(x, y, image);
-  }
-}
-
-void OamCanvas::setScale(unsigned z) {
-  imageSize = 64 * z;
-  setFixedSize(imageSize + frameWidth() * 2, imageSize + frameWidth() * 2);
-  refresh();
-}
-
-void OamCanvas::setSelected(int s) {
-  selected = s;
-}
-
-void OamCanvas::refresh() {
-  if(SNES::cartridge.loaded() && selected >= 0 && selected < 128) {
-    refreshImage(OamObject::getObject(selected));
-  } else {
-    image = QImage();
-  }
-
-  update();
-}
-
-void OamCanvas::refreshImage(const OamObject& obj) {
-  uint32_t palette[16];
-  for(unsigned i = 0; i < 16; i++) {
-    palette[i] = rgbFromCgram(128 + obj.palette * 16 + i);
-  }
-
-  QImage buffer(obj.width, obj.height, QImage::Format_RGB32);
-  const uint8_t *objTileset = SNES::memory::vram.data() + SNES::ppu.oam_tile_addr(obj.table);
-
-  for(unsigned ty = 0; ty < obj.height / 8; ty++) {
-    for(unsigned tx = 0; tx < obj.width / 8; tx++) {
-      unsigned cx = (obj.character + tx) & 0x00f;
-      unsigned cy = (obj.character / 16) + ty;
-      const uint8_t* tile = objTileset + cy * 512 + cx * 32;
-
-      for(unsigned py = 0; py < 8; py++) {
-        uint32_t *dest = ((uint32_t*)buffer.scanLine(ty * 8 + py)) + tx * 8;
-
-        uint8_t d0 = tile[ 0];
-        uint8_t d1 = tile[ 1];
-        uint8_t d2 = tile[16];
-        uint8_t d3 = tile[17];
-        for(unsigned px = 0; px < 8; px++) {
-          uint8_t pixel = 0;
-          pixel |= (d0 & (0x80 >> px)) ? 1 : 0;
-          pixel |= (d1 & (0x80 >> px)) ? 2 : 0;
-          pixel |= (d2 & (0x80 >> px)) ? 4 : 0;
-          pixel |= (d3 & (0x80 >> px)) ? 8 : 0;
-          dest[px] = palette[pixel];
-        }
-        tile += 2;
-      }
-    }
-  }
-
-  int zoom = imageSize / maximumOamBaseSize();
-  int xScale = obj.vFlip ? -zoom : zoom;
-  int yScale = obj.hFlip ? -zoom : zoom;
-
-  image = buffer.transformed(QTransform::fromScale(xScale, yScale), Qt::FastTransformation);
-}
-
-unsigned OamCanvas::maximumOamBaseSize() {
-  switch(SNES::ppu.oam_base_size()) {
-    case 0: return 16;
-    case 1: return 32;
-    case 2: return 64;
-    case 3: return 32;
-    case 4: return 64;
-    case 5: return 64;
-    case 6: return 64;
-    case 7: return 32;
-  }
-  return 16;
+OamViewer::Canvas::Canvas() {
+  image = new QImage(128, 128, QImage::Format_RGB32);
+  image->fill(0x000000);
 }

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -1,62 +1,24 @@
-struct OamObject {
-  unsigned width;
-  unsigned height;
-  signed   xpos;
-  unsigned ypos;
-  unsigned character;
-  unsigned priority;
-  unsigned palette;
-  bool hFlip;
-  bool vFlip;
-  bool table;
-
-  static OamObject getObject(unsigned);
-};
-
-class OamCanvas : public QFrame {
-  Q_OBJECT
-
-public:
-  OamCanvas();
-  void paintEvent(QPaintEvent*);
-
-public slots:
-  void refresh();
-  void setSelected(int);
-  void setScale(unsigned);
-
-private:
-  void refreshImage(const OamObject& obj);
-  unsigned maximumOamBaseSize();
-
-private:
-  int selected;
-  unsigned imageSize;
-  QImage image;
-};
-
 class OamViewer : public Window {
   Q_OBJECT
 
 public:
-  OamViewer();
+  QHBoxLayout *layout;
+  QTreeWidget *list;
+  QVBoxLayout *controlLayout;
+  struct Canvas : public QWidget {
+    QImage *image;
+    void paintEvent(QPaintEvent*);
+    Canvas();
+  } *canvas;
+  QCheckBox *autoUpdateBox;
+  QPushButton *refreshButton;
+
   void autoUpdate();
+  OamViewer();
 
 public slots:
   void show();
   void refresh();
-
-  void onSelectedChanged();
-
-private:
-  QHBoxLayout *layout;
-  QTreeWidget *list;
-  QVBoxLayout *controlLayout;
-  OamCanvas *canvas;
-  QCheckBox *autoUpdateBox;
-  QPushButton *refreshButton;
-
-  bool inRefreshCall;
 };
 
 extern OamViewer *oamViewer;

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
@@ -186,14 +186,13 @@ void VramViewer::onCgramSelectedChanged() {
 }
 
 VramCanvas::VramCanvas() {
-  image = QImage(128, 2048, QImage::Format_RGB32);
-  image.fill(0x800000);
+  image = new QImage(128, 2048, QImage::Format_RGB32);
+  image->fill(0x800000);
 
   zoom = 1;
   selectedColor = 0;
   useCgram = false;
   setDepth2bpp();
-  refreshScaledImage();
 }
 
 void VramCanvas::setDepth2bpp()  { bpp = 2; buildDefaultPalette(); updateWidgetSize(); }
@@ -240,6 +239,7 @@ void VramCanvas::buildCgramPalette() {
 }
 
 void VramCanvas::refresh() {
+  image->fill(0x800000);
   if(SNES::cartridge.loaded()) {
     if(useCgram) buildCgramPalette();
 
@@ -250,13 +250,11 @@ void VramCanvas::refresh() {
     if(bpp == 8) refresh8bpp (source);
     if(bpp == 7) refreshMode7(source);
   }
-
-  refreshScaledImage();
   update();
 }
 
 void VramCanvas::refresh2bpp(const uint8_t *source) {
-  uint32_t *dest = (uint32_t*)image.bits();
+  uint32_t *dest = (uint32_t*)image->bits();
 
   for(unsigned ty = 0; ty < 256; ty++) {
     for(unsigned tx = 0; tx < 16; tx++) {
@@ -276,7 +274,7 @@ void VramCanvas::refresh2bpp(const uint8_t *source) {
 }
 
 void VramCanvas::refresh4bpp(const uint8_t *source) {
-  uint32_t *dest = (uint32_t*)image.bits();
+  uint32_t *dest = (uint32_t*)image->bits();
 
   for(unsigned ty = 0; ty < 128; ty++) {
     for(unsigned tx = 0; tx < 16; tx++) {
@@ -301,7 +299,7 @@ void VramCanvas::refresh4bpp(const uint8_t *source) {
 }
 
 void VramCanvas::refresh8bpp(const uint8_t *source) {
-  uint32_t *dest = (uint32_t*)image.bits();
+  uint32_t *dest = (uint32_t*)image->bits();
 
   for(unsigned ty = 0; ty < 64; ty++) {
     for(unsigned tx = 0; tx < 16; tx++) {
@@ -334,7 +332,7 @@ void VramCanvas::refresh8bpp(const uint8_t *source) {
 }
 
 void VramCanvas::refreshMode7(const uint8_t *source) {
-  uint32_t *dest = (uint32_t*)image.bits();
+  uint32_t *dest = (uint32_t*)image->bits();
 
   for(unsigned ty = 0; ty < 16; ty++) {
     for(unsigned tx = 0; tx < 16; tx++) {
@@ -349,13 +347,8 @@ void VramCanvas::refreshMode7(const uint8_t *source) {
   }
 }
 
-void VramCanvas::refreshScaledImage() {
-  scaledImage = image.scaled(image.width() * zoom, image.height() * zoom, Qt::IgnoreAspectRatio, Qt::FastTransformation);
-}
-
 void VramCanvas::setZoom(unsigned newZoom) {
     zoom = newZoom;
-    refreshScaledImage();
 
     updateWidgetSize();
 }
@@ -372,7 +365,7 @@ void VramCanvas::updateWidgetSize() {
 void VramCanvas::paintEvent(QPaintEvent*) {
   QPainter painter(this);
   painter.setRenderHints(0);
-  painter.drawImage(0, 0, scaledImage);
+  painter.drawImage(0, 0, image->scaled(image->width() * zoom, image->height() * zoom, Qt::IgnoreAspectRatio, Qt::FastTransformation));
 }
 
 void VramViewer::displayInfo(unsigned vram_addr) {

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
@@ -30,12 +30,9 @@ private:
   void refresh4bpp(const uint8_t*);
   void refresh8bpp(const uint8_t*);
   void refreshMode7(const uint8_t*);
-  void refreshScaledImage();
 
 private:
-  QImage image;
-  QImage scaledImage;
-
+  QImage *image;
   unsigned bpp;
   unsigned zoom;
   unsigned selectedColor;

--- a/bsnes/ui-qt/debugger/tools/memory.cpp
+++ b/bsnes/ui-qt/debugger/tools/memory.cpp
@@ -136,7 +136,7 @@ void MemoryEditor::show() {
 void MemoryEditor::sourceChanged(int index) {
   switch(index) { default:
     case 0: memorySource = SNES::Debugger::MemorySource::CPUBus; editor->setEditorSize(16 * 1024 * 1024); break;
-    case 1: memorySource = SNES::Debugger::MemorySource::APUBus; editor->setEditorSize(64 * 1024);        break;
+    case 1: memorySource = SNES::Debugger::MemorySource::APURAM; editor->setEditorSize(64 * 1024);        break;
     case 2: memorySource = SNES::Debugger::MemorySource::VRAM;   editor->setEditorSize(64 * 1024);        break;
     case 3: memorySource = SNES::Debugger::MemorySource::OAM;    editor->setEditorSize(544);              break;
     case 4: memorySource = SNES::Debugger::MemorySource::CGRAM;  editor->setEditorSize(512);              break;
@@ -203,7 +203,7 @@ void MemoryEditor::gotoPrevious(int type) {
   if (memorySource == SNES::Debugger::MemorySource::CPUBus) {
     usage = SNES::cpu.usage;
   }
-  else if (memorySource == SNES::Debugger::MemorySource::APUBus) {
+  else if (memorySource == SNES::Debugger::MemorySource::APURAM) {
     usage = SNES::smp.usage;
   }
   else if (memorySource == SNES::Debugger::MemorySource::CartROM) {
@@ -245,7 +245,7 @@ void MemoryEditor::gotoNext(int type) {
   if (memorySource == SNES::Debugger::MemorySource::CPUBus) {
     usage = SNES::cpu.usage;
   }
-  else if (memorySource == SNES::Debugger::MemorySource::APUBus) {
+  else if (memorySource == SNES::Debugger::MemorySource::APURAM) {
     usage = SNES::smp.usage;
   }
   else if (memorySource == SNES::Debugger::MemorySource::CartROM) {
@@ -436,7 +436,7 @@ uint8_t MemoryEditor::usage(unsigned addr) {
   if (memorySource == SNES::Debugger::MemorySource::CPUBus && addr < 1 << 24) {
     return SNES::cpu.usage[addr];
   }
-  else if (memorySource == SNES::Debugger::MemorySource::APUBus && addr < 1 << 16) {
+  else if (memorySource == SNES::Debugger::MemorySource::APURAM && addr < 1 << 16) {
     return SNES::smp.usage[addr];
   }
   else if (memorySource == SNES::Debugger::MemorySource::CartROM && addr < 1 << 24) {


### PR DESCRIPTION
Reverts sharknnth/bsnes-plus#16