### PR TITLE
reset emulation speed when breakpoints occur fix ignore-input settings with native file dialogues	 fix funky wrapping bug in memory search  account for system state w/r/t/ canvas updates  (i.e. so that non-Qt video drivers will let Qt handle painting when the system isn't actually powered on)

### DIFF
--- a/bsnes/ruby/video/qtopengl.cpp
+++ b/bsnes/ruby/video/qtopengl.cpp
@@ -161,7 +161,6 @@ public:
     widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     layout->addWidget(widget);
     parent->setLayout(layout);
-    parent->setUpdatesEnabled(true);
 
     return true;
   }

--- a/bsnes/ruby/video/qtraster.cpp
+++ b/bsnes/ruby/video/qtraster.cpp
@@ -99,7 +99,6 @@ public:
     widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     layout->addWidget(widget);
     parent->setLayout(layout);
-    parent->setUpdatesEnabled(true);
     clear();
 
     return true;

--- a/bsnes/snes/alt/ppu-compatibility/ppu.hpp
+++ b/bsnes/snes/alt/ppu-compatibility/ppu.hpp
@@ -66,6 +66,7 @@ public:
   void layer_enable(unsigned layer, unsigned priority, bool enable);
   unsigned frameskip;
   unsigned framecounter;
+  unsigned get_frameskip() const { return frameskip; }
   void set_frameskip(unsigned frameskip);
 
   void serialize(serializer&);

--- a/bsnes/snes/alt/ppu-performance/ppu.hpp
+++ b/bsnes/snes/alt/ppu-performance/ppu.hpp
@@ -19,6 +19,7 @@ public:
   void frame();
 
   void layer_enable(unsigned layer, unsigned priority, bool enable);
+  unsigned get_frameskip() const { return display.frameskip; }
   void set_frameskip(unsigned frameskip);
 
   void serialize(serializer&);

--- a/bsnes/snes/ppu/ppu.hpp
+++ b/bsnes/snes/ppu/ppu.hpp
@@ -17,6 +17,7 @@ public:
   void reset();
 
   void layer_enable(unsigned, unsigned, bool) {}
+  unsigned get_frameskip() const { return 0; }
   void set_frameskip(unsigned) {}
 
   void serialize(serializer&);

--- a/bsnes/ui-qt/base/filebrowser.cpp
+++ b/bsnes/ui-qt/base/filebrowser.cpp
@@ -3,12 +3,14 @@ FileBrowser *fileBrowser;
 
 void FileBrowser::chooseFile() {
   if(config().diskBrowser.useCommonDialogs == true) {
+    nativeOpen = true;
     audio.clear();
     QString qfilename = QFileDialog::getOpenFileName(0,
       windowTitle(), fileSystemModel->rootPath(), "All Files (*)"
     );
     string filename = qfilename.toUtf8().constData();
     if(filename != "") onAccept(filename);
+    nativeOpen = false;
     return;
   }
 
@@ -17,6 +19,7 @@ void FileBrowser::chooseFile() {
 
 void FileBrowser::chooseFolder() {
   if(config().diskBrowser.useCommonDialogs == true) {
+    nativeOpen = true;
     audio.clear();
     QString qfilename = QFileDialog::getExistingDirectory(0,
       windowTitle(), config().path.current.folder,
@@ -24,6 +27,7 @@ void FileBrowser::chooseFolder() {
     );
     string filename = qfilename.toUtf8().constData();
     if(filename != "") onAccept(filename);
+    nativeOpen = false;
     return;
   }
 
@@ -40,6 +44,7 @@ void FileBrowser::loadCartridge(CartridgeMode mode, signed filterIndex) {
   string defaultPath = config().path.rom == "" ? config().path.current.cartridge : config().path.rom;
 
   if(config().diskBrowser.useCommonDialogs == true) {
+    nativeOpen = true;
     audio.clear();
     QString qfilename = QFileDialog::getOpenFileName(0,
       windowTitle(), defaultPath, string(
@@ -52,6 +57,7 @@ void FileBrowser::loadCartridge(CartridgeMode mode, signed filterIndex) {
       onAccept(filename);
       config().path.current.cartridge = nall::dir(filename);
     }
+    nativeOpen = false;
     return;
   }
 
@@ -114,6 +120,8 @@ FileBrowser::FileBrowser() {
   connect(this, SIGNAL(activated(const string&)), this, SLOT(activate(const string&)));
   connect(this, SIGNAL(accepted(const string&)), this, SLOT(accept(const string&)));
   connect(previewApplyPatch, SIGNAL(stateChanged(int)), this, SLOT(toggleApplyPatch()));
+  
+  nativeOpen = false;
 }
 
 //

--- a/bsnes/ui-qt/base/filebrowser.moc.hpp
+++ b/bsnes/ui-qt/base/filebrowser.moc.hpp
@@ -11,6 +11,8 @@ public:
   enum CartridgeMode { LoadDirect, LoadBase, LoadSlot1, LoadSlot2 } cartridgeMode;
   void loadCartridge(CartridgeMode, signed = -1);
 
+  bool popupOpen() const { return nativeOpen; }
+
   FileBrowser();
 
 private slots:
@@ -25,6 +27,8 @@ private:
   QWidget *previewImage;
   QWidget *previewSpacer;
   QCheckBox *previewApplyPatch;
+
+  bool nativeOpen;
 
   string resolveFilename(const string&);
   void onChangeCartridge(const string&);

--- a/bsnes/ui-qt/base/main.cpp
+++ b/bsnes/ui-qt/base/main.cpp
@@ -385,7 +385,7 @@ void MainWindow::syncUi() {
 }
 
 bool MainWindow::isActive() {
-  return isActiveWindow() && !isMinimized();
+  return isActiveWindow() && !isMinimized() && !fileBrowser->popupOpen();
 }
 
 void MainWindow::loadCartridge() {

--- a/bsnes/ui-qt/base/main.cpp
+++ b/bsnes/ui-qt/base/main.cpp
@@ -220,9 +220,6 @@ MainWindow::MainWindow() {
       canvas->setFocusPolicy(Qt::StrongFocus);
       canvas->setAttribute(Qt::WA_PaintOnScreen, true);  //disable Qt painting on focus / resize
       canvas->setAttribute(Qt::WA_NoSystemBackground, true);
-      // don't let widget updates temporarily draw a parent widget over an external rendering context
-      // (this is overridden by the Qt-based video drivers)
-      canvas->setUpdatesEnabled(false);
     }
     canvasLayout->addWidget(canvas);
   }

--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -435,6 +435,10 @@ void Debugger::event() {
     } break;
   }
 
+  // disable speedup/slowdown since the main window isn't going to register
+  // the user probably releasing the key while the debug window is active
+  HotkeyInput::releaseSpeedKeys();
+  
   audio.clear();
   autoUpdate();
   activateWindow();

--- a/bsnes/ui-qt/debugger/tools/memory.cpp
+++ b/bsnes/ui-qt/debugger/tools/memory.cpp
@@ -343,6 +343,8 @@ void MemoryEditor::search() {
 void MemoryEditor::searchNext() {
   if (searchStr.size() == 0) return;
 
+  if (searchPos >= editor->editorSize())
+    searchPos = (int)editor->cursorPosition() / 2;
   searchPos = editor->indexOf(searchStr, searchPos + 1);
 
   if (searchPos >= 0) {
@@ -357,6 +359,8 @@ void MemoryEditor::searchNext() {
 void MemoryEditor::searchPrev() {
   if (searchStr.size() == 0) return;
 
+  if (searchPos < 0)
+    searchPos = (int)editor->cursorPosition() / 2;
   searchPos = editor->lastIndexOf(searchStr, searchPos - 1);
 
   if (searchPos >= 0) {

--- a/bsnes/ui-qt/input/input.cpp
+++ b/bsnes/ui-qt/input/input.cpp
@@ -122,6 +122,17 @@ void HotkeyInput::poll() {
 HotkeyInput::HotkeyInput(const char *label, const char *configName) : DigitalInput(label, configName) {
 }
 
+void HotkeyInput::releaseSpeedKeys() {
+  if (UserInterfaceEmulationSpeed::slowdown.isPressed()) {
+    UserInterfaceEmulationSpeed::slowdown.state = 0;
+    UserInterfaceEmulationSpeed::slowdown.released();
+  }
+  if (UserInterfaceEmulationSpeed::speedup.isPressed()) {
+    UserInterfaceEmulationSpeed::speedup.state = 0;
+    UserInterfaceEmulationSpeed::speedup.released();
+  }
+}
+
 //
 
 void InputGroup::attach(MappedInput *input) {

--- a/bsnes/ui-qt/input/input.hpp
+++ b/bsnes/ui-qt/input/input.hpp
@@ -43,6 +43,8 @@ struct HotkeyInput : DigitalInput {
   virtual void released() {}
 
   HotkeyInput(const char*, const char*);
+  
+  static void releaseSpeedKeys();
 };
 
 struct InputGroup : public array<MappedInput*> {

--- a/bsnes/ui-qt/input/userinterface-emulationspeed.cpp
+++ b/bsnes/ui-qt/input/userinterface-emulationspeed.cpp
@@ -9,8 +9,10 @@ namespace UserInterfaceEmulationSpeed {
 struct Slowdown : HotkeyInput {
   bool syncVideo;
   bool syncAudio;
+  unsigned speed;
 
   void pressed() {
+    speed = config().system.speed;
     config().system.speed = 0;
     utility.updateEmulationSpeed();
     syncVideo = config().video.synchronize;
@@ -27,7 +29,7 @@ struct Slowdown : HotkeyInput {
   }
 
   void released() {
-    config().system.speed = 2;
+    config().system.speed = speed;
     utility.updateEmulationSpeed();
     if(syncVideo) {
       config().video.synchronize = true;
@@ -49,11 +51,16 @@ struct Slowdown : HotkeyInput {
 struct Speedup : HotkeyInput {
   bool syncVideo;
   bool syncAudio;
+  unsigned speed;
+  unsigned frameskip;
 
   void pressed() {
-    if(SNES::PPU::SupportsFrameSkip)
+    if(SNES::PPU::SupportsFrameSkip) {
+	  frameskip = SNES::ppu.get_frameskip();
       SNES::ppu.set_frameskip(9);
-
+    }
+    
+    speed = config().system.speed;
     config().system.speed = 4;
     utility.updateEmulationSpeed();
     syncVideo = config().video.synchronize;
@@ -70,10 +77,11 @@ struct Speedup : HotkeyInput {
   }
 
   void released() {
-    if(SNES::PPU::SupportsFrameSkip)
-      SNES::ppu.set_frameskip(0);
-
-    config().system.speed = 2;
+    if(SNES::PPU::SupportsFrameSkip) {
+      SNES::ppu.set_frameskip(frameskip);
+    }
+    
+    config().system.speed = speed;
     utility.updateEmulationSpeed();
     if(syncVideo) {
       config().video.synchronize = true;

--- a/bsnes/ui-qt/utility/system-state.cpp
+++ b/bsnes/ui-qt/utility/system-state.cpp
@@ -100,6 +100,10 @@ void Utility::modifySystemState(system_state_t systemState) {
     } break;
   }
 
+  // don't let widget updates temporarily draw a parent widget over an external rendering contex
+  // (only applies when the system is powered on)
+  mainWindow->canvas->setUpdatesEnabled(!application.power || video.cap("QWidget"));
+
   mainWindow->syncUi();
   #if defined(DEBUGGER)
   debugger->modifySystemState(systemState);


### PR DESCRIPTION
reset emulation speed when breakpoints occur
fix ignore-input settings with native file dialogues	
fix funky wrapping bug in memory search 
account for system state w/r/t/ canvas updates 
(i.e. so that non-Qt video drivers will let Qt handle painting when the
system isn't actually powered on)
